### PR TITLE
Security Fix: Deny users from editing others posts.

### DIFF
--- a/src/app/(main)/editor/[postId]/_components/post-editor.tsx
+++ b/src/app/(main)/editor/[postId]/_components/post-editor.tsx
@@ -27,7 +27,10 @@ const markdownlink = "https://remarkjs.github.io/react-markdown/" // Can also be
 
 interface Props {
   post: RouterOutputs["post"]["get"];
-  user: any;
+}
+
+type usertype = {
+  id: string;
 }
 
 const schema = z.object({
@@ -39,7 +42,7 @@ const schema = z.object({
     .max(2048 * 2),
 });
 
-export const PostEditor = ({ post }: Props) => {
+export const PostEditor = ({ post }: Props, user: usertype) => {
   if (!post) return null;
   const formRef = useRef<HTMLFormElement>(null);
   const updatePost = api.post.update.useMutation();
@@ -52,13 +55,18 @@ export const PostEditor = ({ post }: Props) => {
     resolver: zodResolver(schema),
   });
   const onSubmit = form.handleSubmit(async (values) => {
-    if (user.id !== post.userId) {
-      toast('You do not have permission to edit this post.');
+    if (user.id == post.userId) {
+      updatePost.mutate({ id: post.id, ...values });
       return;
     }
-  
-    updatePost.mutate({ id: post.id, ...values });
+    if (!user) {
+      toast('You need to log in to edit this post.');
+      return;
+    }
+    toast('You do not have permission to edit this post.');
+    return;
   });
+  
 
   return (
     <>

--- a/src/app/(main)/editor/[postId]/_components/post-editor.tsx
+++ b/src/app/(main)/editor/[postId]/_components/post-editor.tsx
@@ -25,12 +25,13 @@ import { toast } from "sonner";
 
 const markdownlink = "https://remarkjs.github.io/react-markdown/" // Can also be changed for something like /markdown
 
-interface Props {
-  post: RouterOutputs["post"]["get"];
-}
-
 type usertype = {
   id: string;
+}
+
+interface Props {
+  post: RouterOutputs["post"]["get"];
+  user: usertype;
 }
 
 const schema = z.object({
@@ -42,7 +43,7 @@ const schema = z.object({
     .max(2048 * 2),
 });
 
-export const PostEditor = ({ post }: Props, user: usertype) => {
+export const PostEditor = ({ post, user }: Props) => {
   if (!post) return null;
   const formRef = useRef<HTMLFormElement>(null);
   const updatePost = api.post.update.useMutation();

--- a/src/app/(main)/editor/[postId]/_components/post-editor.tsx
+++ b/src/app/(main)/editor/[postId]/_components/post-editor.tsx
@@ -50,6 +50,11 @@ export const PostEditor = ({ post }: Props) => {
     resolver: zodResolver(schema),
   });
   const onSubmit = form.handleSubmit(async (values) => {
+    if (user.id !== post.userId) {
+      toast('You do not have permission to edit this post.');
+      return;
+    }
+  
     updatePost.mutate({ id: post.id, ...values });
   });
 

--- a/src/app/(main)/editor/[postId]/_components/post-editor.tsx
+++ b/src/app/(main)/editor/[postId]/_components/post-editor.tsx
@@ -21,11 +21,13 @@ import { api } from "@/trpc/react";
 import { Pencil2Icon } from "@/components/icons";
 import { LoadingButton } from "@/components/loading-button";
 import Link from "next/link";
+import { toast } from "sonner";
 
 const markdownlink = "https://remarkjs.github.io/react-markdown/" // Can also be changed for something like /markdown
 
 interface Props {
   post: RouterOutputs["post"]["get"];
+  user: any;
 }
 
 const schema = z.object({

--- a/src/app/(main)/editor/[postId]/_components/post-editor.tsx
+++ b/src/app/(main)/editor/[postId]/_components/post-editor.tsx
@@ -58,12 +58,10 @@ export const PostEditor = ({ post, user }: Props) => {
   const onSubmit = form.handleSubmit(async (values) => {
     if (user.id == post.userId) {
       updatePost.mutate({ id: post.id, ...values });
+      toast('Saved the post successfully.');
       return;
     }
-    if (!user) {
-      toast('You need to log in to edit this post.');
-      return;
-    }
+
     toast('You do not have permission to edit this post.');
     return;
   });

--- a/src/app/(main)/editor/[postId]/page.tsx
+++ b/src/app/(main)/editor/[postId]/page.tsx
@@ -29,7 +29,7 @@ export default async function EditPostPage({ params }: Props) {
         <ArrowLeftIcon className="h-5 w-5" /> back to dashboard
       </Link>
 
-      <PostEditor post={post} />
+      <PostEditor post={post} user={user} />
     </main>
   );
 }


### PR DESCRIPTION
# Description

Users currently can go to other peoples posts and edit them without any checks if its their post or not, all they have to do is figure out the id for the post and go to /editor/[postId], do their edits and save it.

This can be very bad (not so much in this circumstance).

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires installing new dependencies
- [X] Security fix.
